### PR TITLE
Init portlet manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,9 @@ Blueprints provided by this package
     - Blueprint to convert the very old PloneFormMailer fields to the new
     PloneFormGen archetype fields
 
+- ftw.blueprints.contextualprtletadder
+    - Adds a portlet on a given context
+
 <!-- Under construction - deprecated -->
 
 - ftw.blueprints.annotatedefaultviewpathobjects
@@ -493,8 +496,45 @@ Full configuration
         'retract': 'intranet_secure_workflow--TRANSITION--retract'}
 
 
+ftw.blueprints.contextualportletadder
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Blueprint to insert a portlet on a given context.
+
+Required options:
+
+- manager-name
+    - Name of the portletmanager you want to add a portlet
+    - String
+
+- assignment-path
+    - Dotted name path to the portlet assignment you want to add
+    - String
+
+- portlet-id
+    - ID of the portlet you want to add
+    - String
+
+Minimal configuration:
+
+.. code:: cfg
+
+    [contextualportletadder]
+    blueprint = ftw.blueprints.contextualportletadder
+    manager-name = plone.rightcolumn
+    assignment-path = ftw.contentpage.portlets.news_archive_portlet.Assignment
+    portlet-id = news_archive_portlet
+
+
+Optional options:
+
+- portlet-properties
+    - Default properties for the portlet assignment
+    - expression, dict
+
+
 ftw.blueprints.formmailer-fields-inserter
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Blueprint to convert the very old PloneFormMailer fields to the new
 PloneFormGen archetype fields

--- a/ftw/blueprints/sections/configure.zcml
+++ b/ftw/blueprints/sections/configure.zcml
@@ -50,4 +50,8 @@
       component=".workflow.WorkflowManager"
       name="ftw.blueprints.workflowmanager"
       />
+  <utility
+      component=".portlet.ContextualPortletAdder"
+      name="ftw.blueprints.ContextualPortletAdder"
+      />
 </configure>

--- a/ftw/blueprints/sections/portlet.py
+++ b/ftw/blueprints/sections/portlet.py
@@ -1,0 +1,95 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from collective.transmogrifier.utils import Condition
+from collective.transmogrifier.utils import Expression
+from collective.transmogrifier.utils import traverse
+from importlib import import_module
+from plone.portlets.interfaces import IPortletAssignmentMapping
+from plone.portlets.interfaces import IPortletManager
+from zope.component import getMultiAdapter
+from zope.component import getUtility
+from zope.interface import classProvides, implements
+import logging
+
+
+class PortletHandler(object):
+
+    def __init__(self, manager_name, assignment_path, portlet_id):
+        self.manager_name = manager_name
+        self.portlet_id = portlet_id
+        self.assignment_path = assignment_path
+
+    def __call__(self, context, properties=None):
+        properties = properties or {}
+        manager = getUtility(IPortletManager, name=self.manager_name)
+        assignment_mapping = getMultiAdapter(
+            (context, manager), IPortletAssignmentMapping)
+
+        # Set new portlet assignment
+        if self.portlet_id in assignment_mapping:
+            return
+
+        assignment_mapping[self.portlet_id] = self.get_assignment_object(
+            properties)
+
+    def get_assignment_object(self, properties=None):
+        """Return the assignment object of the defined portlet
+        """
+        properties = properties or {}
+        assignment_class = self._get_assignment_class(self.assignment_path)
+
+        return assignment_class(**properties)
+
+    def _get_assignment_class(self, assignment_path):
+        """Try to import and return the defined assignment class
+        """
+        path_elements = assignment_path.split('.')
+
+        module = import_module('.'.join(path_elements[:-1]))
+        assignment_class_name = path_elements[-1]
+
+        return getattr(module, assignment_class_name)
+
+
+class ContextualPortletAdder(object):
+    classProvides(ISectionBlueprint)
+    implements(ISection)
+
+    def __init__(self, transmogrifier, name, options, previous):
+        self.previous = previous
+        self.context = transmogrifier.context
+        self.logger = logging.getLogger(options['blueprint'])
+
+        self.pathkey = options.get('path-key', '_path')
+
+        self.portlet_properties = Expression(
+            options.get('portlet-properties', 'python:{}'),
+            transmogrifier, name, options)
+
+        self.condition = Condition(options.get('condition', 'python:True'),
+            transmogrifier, name, options)
+
+        self.portlet_handler = PortletHandler(
+            options.get('manager-name'),
+            options.get('assignment-path'),
+            options.get('portlet-id')
+        )
+
+    def __iter__(self):
+        for item in self.previous:
+            if not self.condition(item):
+                yield item
+                continue
+
+            obj = traverse(self.context, item.get(self.pathkey, ''))
+
+            if not obj:
+                self.logger.warn(
+                    "Context does not exist at %s" % item.get[self.pathkey])
+                yield item
+                continue
+
+            self.portlet_handler(obj, self.portlet_properties(item))
+
+            self.logger.info(
+                "Added portlet at %s" % (item[self.pathkey]))

--- a/ftw/blueprints/tests/test_portlet.py
+++ b/ftw/blueprints/tests/test_portlet.py
@@ -1,0 +1,51 @@
+from ftw.blueprints.sections.portlet import PortletHandler
+from unittest2 import TestCase
+
+
+class DummyAssignment(object):
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+DUMMY_ASSIGNMENT_PATH = 'ftw.blueprints.tests.test_portlet.DummyAssignment'
+
+class TestPortletHandlerAssignmentObject(TestCase):
+
+    def get_handler(self, path=DUMMY_ASSIGNMENT_PATH):
+        return PortletHandler(
+            'manager_name',
+            path,
+            'portlet_id')
+
+    def test_get_instance_of_dummyassignment_class(self):
+        handler = self.get_handler()
+        assignment_obj = handler.get_assignment_object()
+        self.assertEquals(DummyAssignment, assignment_obj.__class__)
+
+    def test_get_dummyassignment_without_properties(self):
+        handler = self.get_handler()
+        assignment_obj = handler.get_assignment_object()
+        self.assertEquals(assignment_obj.kwargs, {})
+
+    def test_get_dummyassignent_with_a_property(self):
+        handler = self.get_handler()
+        assignment_obj = handler.get_assignment_object(dict(title='Test'))
+        self.assertEquals(assignment_obj.kwargs, {'title': 'Test'})
+
+    def test_raise_importerror_if_the_path_to_assignment_class_does_not_exist(self):
+        handler = self.get_handler('ftw.blueprints.not-existing.path')
+
+        with self.assertRaises(ImportError) as err:
+            handler.get_assignment_object()
+
+        self.assertIn('not-existing', str(err.exception))
+
+    def test_raise_attributeerror_if_the_assignment_class_does_not_exist(self):
+        handler = self.get_handler(
+            'ftw.blueprints.tests.test_portlet.not-existing-class')
+
+        with self.assertRaises(AttributeError) as err:
+            handler.get_assignment_object()
+
+        self.assertIn('not-existing-class', str(err.exception))


### PR DESCRIPTION
:construction: 
@phgross @Tschanzt  Hier ist mal eine erste Version des Porteltmanagers.

Momentan verwende ich nur das Handlerobjekt von einem Script aus, nicht den Blueprint selbst.
Ich glaube, dies ist eine erste Basis für die Portletmigration welche Timon dann braucht.

Meine Implementation fügt für einen bestimmten Kontext ein bestimmtes Portlet hinzu.

Noch nicht implementiert sind allgemeine Portletmanagereinstellungen wie z.B. show, block und aquire. Auch fehlt eine Portletmigration mit 'portal_type' und 'group'.
