### PR TITLE
Remove unused test cfg for incompatible plone 4.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,12 +29,7 @@ Installation
 Compatibility
 -------------
 
-Runs with `Plone <http://www.plone.org/>`_ `4.1`, `4.2` or `4.3`.
-
-Plone 4.1
-
-.. image:: https://jenkins.4teamwork.ch/job/ftw.blueprints-master-test-plone-4.1.x.cfg/badge/icon
-   :target: https://jenkins.4teamwork.ch/job/ftw.blueprints-master-test-plone-4.1.x.cfg
+Runs with `Plone <http://www.plone.org/>`_ `4.2` or `4.3`.
 
 Plone 4.2
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(name='ftw.blueprints',
 
       classifiers=[
         'Framework :: Plone',
-        'Framework :: Plone :: 4.1',
         'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',
         'Intended Audience :: Developers',

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -1,6 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.1.x.cfg
-    sources.cfg
-
-package-name = ftw.blueprints


### PR DESCRIPTION
@jone #7 needs the importlib module which is available in python >= 2.7. ftw.blueprint doesn't need to be compatible with plone 4.1.
