### PR TITLE
Fix plone.multilingual import error.

### DIFF
--- a/ftw/blueprints/sections/configure.zcml
+++ b/ftw/blueprints/sections/configure.zcml
@@ -1,6 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:transmogrifier="http://namespaces.plone.org/transmogrifier">
+    xmlns:transmogrifier="http://namespaces.plone.org/transmogrifier"
+    xmlns:zcml="http://namespaces.zope.org/zcml">
 
     <utility
         component=".mapper.FieldMapper"
@@ -83,6 +84,7 @@
         />
 
     <utility
+        zcml:condition="installed plone.multilingual"
         component=".multilingual.LinguaPloneItemLinker"
         name="ftw.blueprints.multilingual.linguaploneitemlinker"
         />


### PR DESCRIPTION
The multilingual section depends on plone.multilingual, which is not a dependency
nor is it Plone core.

The section should only be available when plone.multilingual is actually installed.

Fixes #14 
/cc @maethu @deiferni 
