### PR TITLE
Add position updater section.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,9 @@ Blueprints provided by this package
    - Create new translations with plone.app.multilingual from a source that used
      LinguaPlone.
 
+- ftw.blueprints.positionupdater
+   - A object position in parent blueprint, supporting Plone sites.
+
 - Under construction / deprecated
    - ftw.blueprints.annotatedefaultviewpathobjects
    - ftw.blueprints.updatedefaultviewobjectpath
@@ -274,7 +277,7 @@ Required options:
   - The first level maps types.
 
   - The second levels maps fields of the first level's types.
-  
+
   - expression, dict
 
 Minimal configuration:
@@ -692,6 +695,29 @@ Optional options:
 - translationOf
   - The key-name for the reference to the canonical translation. It defaults to
   _translationOf.
+
+
+ftw.blueprints.positionupdater
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``positionupdater`` blueprint supports folders and Plone sites.
+It stores the desired position of each object in its annotations,
+so that we can migrate children separately but keep the position
+(e.g. one FTI at a time).
+
+.. code:: cfg
+
+    [position]
+    blueprint = ftw.blueprints.positionupdater
+
+Optional:
+
+- ``path-key``
+  - The key-name for the new item's path. It defaults to ``_path``.
+
+- ``position-key``
+  - The key-name for the item's position. It defaults to ``_gopip``.
+
 
 Links
 -----

--- a/ftw/blueprints/sections/configure.zcml
+++ b/ftw/blueprints/sections/configure.zcml
@@ -84,6 +84,11 @@
         />
 
     <utility
+        component=".position.PositionInParentUpdater"
+        name="ftw.blueprints.positionupdater"
+        />
+
+    <utility
         zcml:condition="installed plone.multilingual"
         component=".multilingual.LinguaPloneItemLinker"
         name="ftw.blueprints.multilingual.linguaploneitemlinker"

--- a/ftw/blueprints/sections/position.py
+++ b/ftw/blueprints/sections/position.py
@@ -1,0 +1,68 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from collective.transmogrifier.utils import defaultMatcher
+from operator import itemgetter
+from zope.annotation.interfaces import IAnnotations
+from zope.interface import classProvides, implements
+
+
+ANNOTATION_KEY = 'ftw.blueprints-position'
+
+
+class PositionInParentUpdater(object):
+    classProvides(ISectionBlueprint)
+    implements(ISection)
+
+    def __init__(self, transmogrifier, name, options, previous):
+        self.previous = previous
+        self.context = transmogrifier.context
+        self.pathkey = defaultMatcher(options, 'path-key', name, 'path')
+        self.positionkey = defaultMatcher(options, 'position-key', name, 'gopip')
+
+    def __iter__(self):
+        for item in self.previous:
+            keys = item.keys()
+            pathkey = self.pathkey(*keys)[0]
+            positionkey = self.positionkey(*keys)[0]
+            path = item[pathkey]
+            position = item.get(positionkey)
+
+            obj = self.context.unrestrictedTraverse(
+                str(path).lstrip('/'), None)
+            if obj is not None:
+                self.updateObjectPosition(obj, position)
+
+            yield item
+
+    def updateObjectPosition(self, obj, position):
+        """Store the position we want on the object and order all children
+        of the parent according to their stored positions.
+
+        This allows to partially migrate different types in a folder in different
+        steps and will reorder already migrated siblings correctly because we
+        have stored the position from the source installation.
+        """
+
+        self.store_position_for_obj(obj, position)
+        parent = aq_parent(aq_inner(obj))
+        self.reorder_children(parent)
+
+    def store_position_for_obj(self, obj, position):
+        IAnnotations(obj)[ANNOTATION_KEY] = position
+
+    def reorder_children(self, obj):
+        ordered_sibling_ids = self.get_ordered_children_ids_from_annotations(obj)
+        obj.moveObjectsByDelta(ordered_sibling_ids, - len(ordered_sibling_ids))
+
+    def get_ordered_children_ids_from_annotations(self, container):
+        def get_position_from_annotations(item):
+            id_, obj = item
+            try:
+                return IAnnotations(obj)[ANNOTATION_KEY]
+            except (TypeError, KeyError):
+                return 10000
+
+        ordered_children = sorted(container.objectItems(), key=get_position_from_annotations)
+        return map(itemgetter(0), ordered_children)

--- a/ftw/blueprints/tests/test_position.py
+++ b/ftw/blueprints/tests/test_position.py
@@ -1,0 +1,84 @@
+from ftw.blueprints.sections.position import PositionInParentUpdater
+from ftw.blueprints.testing import BLUEPRINT_INTEGRATION_TESTING
+from ftw.blueprints.tests.base import BlueprintTestCase
+from ftw.blueprints.tests.utils import TestTransmogrifier
+from ftw.builder import Builder
+from ftw.builder import create
+from plone.app.testing.helpers import setRoles
+from plone.app.testing.interfaces import TEST_USER_ID
+from Products.CMFCore.utils import getToolByName
+
+
+class TestPositionInParentUpdater(BlueprintTestCase):
+    layer = BLUEPRINT_INTEGRATION_TESTING
+    klass = PositionInParentUpdater
+
+    def setUp(self):
+        super(TestPositionInParentUpdater, self).setUp()
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+
+    def test_updating_object_position_in_folder(self):
+        folder = create(Builder('folder').titled('folder'))
+        create(Builder('folder').titled('three').within(folder))
+        create(Builder('folder').titled('two').within(folder))
+        create(Builder('folder').titled('one').within(folder))
+
+        self.assert_obj_positions(folder, ['three', 'two', 'one'])
+        self.assert_catalog_positions(folder, ['three', 'two', 'one'])
+
+        self.run_transmogrifier([{'_path': 'folder/one', '_gopip': 11},
+                                 {'_path': 'folder/two', '_gopip': 22},
+                                 {'_path': 'folder/three', '_gopip': 33}])
+
+        self.assert_obj_positions(folder, ['one', 'two', 'three'])
+        self.assert_catalog_positions(folder, ['one', 'two', 'three'])
+
+        self.run_transmogrifier([{'_path': 'folder/three', '_gopip': 33}])
+        self.run_transmogrifier([{'_path': 'folder/two', '_gopip': 22}])
+        self.run_transmogrifier([{'_path': 'folder/one', '_gopip': 11}])
+
+        self.assert_obj_positions(folder, ['one', 'two', 'three'])
+        self.assert_catalog_positions(folder, ['one', 'two', 'three'])
+
+    def test_updating_object_position_in_plone_site(self):
+        create(Builder('folder').titled('three'))
+        create(Builder('folder').titled('two'))
+        create(Builder('folder').titled('one'))
+
+        self.assert_obj_positions(self.portal, ['three', 'two', 'one'])
+        self.assert_catalog_positions(self.portal, ['three', 'two', 'one'])
+
+        self.run_transmogrifier([{'_path': 'one', '_gopip': 11},
+                                 {'_path': 'two', '_gopip': 22},
+                                 {'_path': 'three', '_gopip': 33}])
+
+        self.assert_obj_positions(self.portal, ['one', 'two', 'three'])
+        self.assert_catalog_positions(self.portal, ['one', 'two', 'three'])
+
+        self.run_transmogrifier([{'_path': 'three', '_gopip': 33}])
+        self.run_transmogrifier([{'_path': 'two', '_gopip': 22}])
+        self.run_transmogrifier([{'_path': 'one', '_gopip': 11}])
+
+        self.assert_obj_positions(self.portal, ['one', 'two', 'three'])
+        self.assert_catalog_positions(self.portal, ['one', 'two', 'three'])
+
+    def run_transmogrifier(self, items):
+        transmogrifier = TestTransmogrifier()
+        transmogrifier.context = self.portal
+        options = {'blueprint': 'ftw.blueprints.positionupdater'}
+        source = self.klass(transmogrifier, 'test', options, items)
+        return list(source)
+
+    def assert_obj_positions(self, container, expected):
+        got = [id_ for id_ in container.objectIds() if id_ in expected]
+        self.assertEquals(expected, got)
+
+    def assert_catalog_positions(self, container, expected):
+        catalog = getToolByName(self.portal, 'portal_catalog')
+        query = {'path': {'query': '/'.join(container.getPhysicalPath()),
+                          'depth': 1},
+                 'id': expected,
+                 'sort_on': 'getObjPositionInParent'}
+        got = [brain.getId for brain in catalog(query)]
+        self.assertEquals(expected, got, 'Catalog indexes not up to date.')


### PR DESCRIPTION
The position updater section supports reordering children of folders as well as children of Plone sites, by using ``moveObjectsByDelta`` it uses the Zope public interface and is agnostic to the underlying implementation.

It also supports partial updates by storing the desired object positions in the annotations for later use.

@mbaechtold 
/cc Mr. Migrator @phgross :wink: 